### PR TITLE
Renders ALL assets, and streams in TOC, should line up TOC to map in …

### DIFF
--- a/ooiui/static/css/common/toc_menu.css
+++ b/ooiui/static/css/common/toc_menu.css
@@ -148,3 +148,7 @@ button#search-clear {
 #streamPanel {
   padding-left: 15px;
 }
+/* styling for items with no children */
+.no-children {
+    color: grey;
+}

--- a/ooiui/static/js/views/common/TOCView.js
+++ b/ooiui/static/js/views/common/TOCView.js
@@ -184,8 +184,9 @@ var AssetItemView = Backbone.View.extend({
             this.derender();
         });
         this.listenTo(vent, 'toc:cleanUp', function() {
+            // if the item doesn't have any children, grey it out.
             if ( this.$el.find('ul.tree').children().length == 0 ) {
-                this.$el.attr('style', 'color:grey');
+                this.$el.addClass('no-children');
             }
         });
     },

--- a/ooiui/templates/science/index.html
+++ b/ooiui/templates/science/index.html
@@ -154,7 +154,6 @@ $.when(arrayFetch).done(function() {
             $.when( (renderTOCView( arrayCollection, assetCollection, streamCollection )) ).done(function() {
                 // right now we need to call this twice...not sure why.
                 vent.trigger('toc:cleanUp');
-                vent.trigger('toc:cleanUp');
             });
         });
     });

--- a/ooiui/templates/science/streams.html
+++ b/ooiui/templates/science/streams.html
@@ -173,7 +173,7 @@ _.extend(OOI.prototype, Backbone.Events, {
 
     // TOC Controls
     this.listenTo(this, 'toc:selectPlatform', function(model) {
-        var searchFor = model.get('ref_des').substr(0,8);
+        var searchFor = model.get('ref_des').substr(0,14);
         $('#search').val(searchFor);
         $('#search-clear').show();
         updateCollection( showStreams );


### PR DESCRIPTION
…1 to 1 as well as Data Catalog and plotting.

@DanielJMaher , @Bobfrat , @birdage : 

So this PR gets all the assets to render in the TOC, so it now matches 1 to 1 TOC:Map assets, and TOC:stream in data catalog.

An interesting evolution that happened was that all orphaned streams (that have no instruments) list below it's would be parents asset.  Could you just review that this is a good side effect or a negative one?  I thought it would be useful, but I'd just like to confirm:

![screen shot 2015-08-16 at 12 17 42 pm](https://cloud.githubusercontent.com/assets/3743882/9294128/e2cfa0b6-4411-11e5-8c56-8e89c49534b8.png)
