### PR TITLE
Remove redirect from troubleticket submission

### DIFF
--- a/ooiui/templates/common/troubleTicket.html
+++ b/ooiui/templates/common/troubleTicket.html
@@ -100,9 +100,6 @@ _.extend(OOI.prototype, Backbone.Events, {
     });
 
     $('#page-content-wrapper').prepend(this.views.ticket.el);
-    // this.listenTo(this, "TroubleTicketView:submit", function(model) {
-      // window.location.href = '/';
-    // });
   }
 });
 var ooi = new OOI();

--- a/ooiui/templates/common/troubleTicket.html
+++ b/ooiui/templates/common/troubleTicket.html
@@ -100,9 +100,9 @@ _.extend(OOI.prototype, Backbone.Events, {
     });
 
     $('#page-content-wrapper').prepend(this.views.ticket.el);
-    this.listenTo(this, "TroubleTicketView:submit", function(model) {
-      window.location.href = '/';
-    });
+    // this.listenTo(this, "TroubleTicketView:submit", function(model) {
+      // window.location.href = '/';
+    // });
   }
 });
 var ooi = new OOI();


### PR DESCRIPTION
@DanielJMaher @birdage 

Currently when you submit a trouble ticket it redirects you to the home page after you hit submit so you dont ever see the success or error modals that pop up indicating whether the ticket was submitted successfully. This just removes that functionality