### PR TITLE
use the new 'deployment' arg to get deployment events associated even…

### DIFF
--- a/ooiui/static/js/views/common/MapView.js
+++ b/ooiui/static/js/views/common/MapView.js
@@ -35,7 +35,8 @@ var MapView = Backbone.View.extend({
 
         //this.listenTo(ooi.models.mapModel, 'change', this.setMapView);
 
-        this.collection.fetch({success: function(collection, response, options) {
+        var data = { min : 'True', deployments : 'True' };
+        this.collection.fetch({ data: data, success: function(collection, response, options) {
             self.render();
             return this;
         }});


### PR DESCRIPTION
… when minified

@birdage , this (along with the services PR) address the issue you saw last night; reducing the json size to 1.5 MB.  Still large, but much better than 8+MB!

