### PR TITLE
use a redirect form the response to a GET request, rather than a just…

### DIFF
--- a/ooiui/core/routes/common.py
+++ b/ooiui/core/routes/common.py
@@ -268,7 +268,8 @@ def login():
 
 @app.route('/api/cilogon', methods=['GET'])
 def ci_logon():
-    return redirect(app.config['SERVICES_URL'] + '/authorize/cilogon')
+    response = requests.get(app.config['SERVICES_URL'] = '/authorize/cilogn')
+    return redirect(response.location)
 
 
 @app.route('/callback/cilogon', methods=['GET'])


### PR DESCRIPTION
… a redirect
@DanielJMaher , @oceanzus 

This looks like it should work now; we're using the response from a GET rather than sending the client to the services.