### PR TITLE
Fix to get the filter working properly on reload of TOC

### DIFF
--- a/ooiui/static/js/models/common/PageControlModels.js
+++ b/ooiui/static/js/models/common/PageControlModels.js
@@ -25,54 +25,53 @@ var TocPageControlModel = Backbone.Model.extend({
 
         params : {
             "General":[
-                ["CTDAVN CTDBPC CTDBPD CTDBPE CTDBPF CTDBPN CTDBPO CTDBPP CTDGVM CTDMOG CTDMOH CTDMOQ CTDMOR CTDPFA CTDPFB CTDPFJ CTDPFK CTDPFL", "Water Temperature"],
-                ["PRESFA PRESFB PRESFC PRESTA PRESTB CTDAVN CTDBPC CTDBPD CTDBPE CTDBPF CTDBPN CTDBPO CTDBPP CTDGVM CTDMOG CTDMOH CTDMOQ CTDMOR CTDPFA CTDPFB CTDPFJ CTDPFK CTDPFL", "Pressure"],
-                ['PHSENA PHSENB PHSEND PHSENE PHSENF', 'pH'],
-                ['NUTNRB NUTNRA NUTNRM', 'Nitrate'],
-                ['CTDAVN CTDBPC CTDBPD CTDBPE CTDBPF CTDBPN CTDBPO CTDBPP CTDGVM CTDMOG CTDMOH CTDMOQ CTDMOR CTDPFA CTDPFB CTDPFJ CTDPFK CTDPFL', 'Density'],
-                ['CTDAVN CTDBPC CTDBPD CTDBPE CTDBPF CTDBPN CTDBPO CTDBPP CTDGVM CTDMOG CTDMOH CTDMOQ CTDMOR CTDPFA CTDPFB CTDPFJ CTDPFK CTDPFL', 'Salinity']
-                ['OPTAAC OPTAAD OPTAAJ FLNTUA FLCDRA FLORDD FLORDL FLORDM FLORTD FLORTJ FLORTK FLORTM', 'Chlorophyll'],
-                ['OPTAAC OPTAAD OPTAAJ', 'Turbidity']
+                ['CTDAVN CTDBPC CTDBPD CTDBPE CTDBPF CTDBPN CTDBPO CTDBPP CTDGVM CTDMOG CTDMOH CTDMOQ CTDMOR CTDPFA CTDPFB CTDPFJ CTDPFK CTDPFL CTDWaterTempGen', 'Water Temperature'],
+                ['PRESFA PRESFB PRESFC PRESTA PRESTB CTDAVN CTDBPC CTDBPD CTDBPE CTDBPF CTDBPN CTDBPO CTDBPP CTDGVM CTDMOG CTDMOH CTDMOQ CTDMOR CTDPFA CTDPFB CTDPFJ CTDPFK CTDPFL CTDPress', 'Pressure'],
+                ['PHSENA PHSENB PHSEND PHSENE PHSENF PHpH', 'pH'],
+                ['NUTNRB NUTNRA NUTNRM NUTNRNitrate', 'Nitrate'],
+                ['CTDAVN CTDBPC CTDBPD CTDBPE CTDBPF CTDBPN CTDBPO CTDBPP CTDGVM CTDMOG CTDMOH CTDMOQ CTDMOR CTDPFA CTDPFB CTDPFJ CTDPFK CTDPFL CTDDensity', 'Density'],
+                ['CTDAVN CTDBPC CTDBPD CTDBPE CTDBPF CTDBPN CTDBPO CTDBPP CTDGVM CTDMOG CTDMOH CTDMOQ CTDMOR CTDPFA CTDPFB CTDPFJ CTDPFK CTDPFL CTDSalinGen', 'Salinity'],
+                ['OPTAAC OPTAAD OPTAAJ FLNTUA FLCDRA FLORDD FLORDL FLORDM FLORTD FLORTJ FLORTK FLORTM FLORTChloro', 'Chlorophyll'],
+                ['OPTAAC OPTAAD OPTAAJ OPTAATurbid', 'Turbidity']
             ],
             "Air Sea Interface":[
-                ['FDCHPA METBKA', 'Air Temperature'],
-                ['FDCHPA METBKA', 'Humidity'],
-                ['FDCHPA METBKA', 'Wind Velocity'],
-                ['METBKA', 'Precipitation'],
-                ['PC02AA', 'Atmospheric CO2'],
-                ['PC02AA', 'Air-Sea CO2 Flux'],
-                ['PC02WA PC02WB PC02WC PC02AA', 'Seawater CO2'],
-                ['METBKA FDCHPA', 'Air-Sea Heat Flux'],
-                ['METBKA', 'Downwelling Irradiance'],
-                ['METBKA', 'Atmospheric Pressure'],
-                ['CTDAVN CTDBPC CTDBPD CTDBPE CTDBPF CTDBPN CTDBPO CTDBPP CTDGVM CTDMOG CTDMOH CTDMOQ CTDMOR CTDPFA CTDPFB CTDPFJ CTDPFK CTDPFL METBKA', 'Water Temperature'],
-                ['CTDAVN CTDBPC CTDBPD CTDBPE CTDBPF CTDBPN CTDBPO CTDBPP CTDGVM CTDMOG CTDMOH CTDMOQ CTDMOR CTDPFA CTDPFB CTDPFJ CTDPFK CTDPFL METBKA', 'Salinity'],
-                ['METBKA', 'Humidity'],
-                ['WAVSSA', 'Wave Properties']
+                ['FDCHPA METBKA FDCMETAirTemp', 'Air Temperature'],
+                ['FDCHPA METBKA FDCMETHumid', 'Humidity'],
+                ['FDCHPA METBKA FDCMETWindVelo', 'Wind Velocity'],
+                ['METBKA METBKAPrecip', 'Precipitation'],
+                ['PC02AA PC02Atmo', 'Atmospheric CO2'],
+                ['PC02AA PC02Air-Sea', 'Air-Sea CO2 Flux'],
+                ['PC02WA PC02WB PC02WC PC02AA PC02Sea', 'Seawater CO2'],
+                ['FDCHPA METBKA FDCMETAir-SeaHeat', 'Air-Sea Heat Flux'],
+                ['METBKA METBKADownIrrad', 'Downwelling Irradiance'],
+                ['METBKA METBKAAtmoPress', 'Atmospheric Pressure'],
+                ['CTDAVN CTDBPC CTDBPD CTDBPE CTDBPF CTDBPN CTDBPO CTDBPP CTDGVM CTDMOG CTDMOH CTDMOQ CTDMOR CTDPFA CTDPFB CTDPFJ CTDPFK CTDPFL METBKA CTDWaterTempAir-Sea', 'Water Temperature'],
+                ['CTDAVN CTDBPC CTDBPD CTDBPE CTDBPF CTDBPN CTDBPO CTDBPP CTDGVM CTDMOG CTDMOH CTDMOQ CTDMOR CTDPFA CTDPFB CTDPFJ CTDPFK CTDPFL METBKA CTDSalinAir-Sea', 'Salinity'],
+                ['METBKA METBKAHumid', 'Humidity'],
+                ['WAVSSA WAVSSAWave', 'Wave Properties']
             ],
             "Water Column": [
-                ['SPKIRA SPKIRB SPKIRJ', 'Spectral Irradiance'],
-                ['PARADA PARADJ PARADK PARADM', 'PAR'],
-                ['VADCPA VEL3DB VEL3DC VEL3DD VEL3DK VEL3DL VELPTA VELPTB VELPTD VELPTJ ADCPAM ADCPSI ADCPSJ ADCPSK ADCPSL ADCPSN ADCPTA ADCPTB ADCPTD ADCPTE ADCPTF ADCPTG ADCPTM', 'Water Velocity'],
-                ['ZPLSCB ZPLSCC', 'Bioacoustic Sonar'],
-                ['ADCPTA ADCPTB ADCPTD ADCPTE ADCPTF ADCPTG ADCPTM', 'Wave Properties'],
-                ['FLNTUA FLCDRA FLORDD FLORDL FLORDM FLORTD FLORTJ FLORTK FLORTM', 'Turbidity']
+                ['SPKIRA SPKIRB SPKIRJ SPIKRSpectral', 'Spectral Irradiance'],
+                ['PARADA PARADJ PARADK PARADM PARADPAR', 'PAR'],
+                ['VADCPA VEL3DB VEL3DC VEL3DD VEL3DK VEL3DL VELPTA VELPTB VELPTD VELPTJ ADCPAM ADCPSI ADCPSJ ADCPSK ADCPSL ADCPSN ADCPTA ADCPTB ADCPTD ADCPTE ADCPTF ADCPTG ADCPTM ADCWaterVelo', 'Water Velocity'],
+                ['ZPLSCB ZPLSCC ZPLSCBioacoustic', 'Bioacoustic Sonar'],
+                ['ADCPTA ADCPTB ADCPTD ADCPTE ADCPTF ADCPTG ADCPTM ADCPWaveProps', 'Wave Properties'],
+                ['FLNTUA FLCDRA FLORDD FLORDL FLORDM FLORTD FLORTJ FLORTK FLORTM FLORTTurbid', 'Turbidity']
             ],
             "Seafloor": [
-                ['HYDBBA HYDLFA', 'Hydrophone'],
-                ['MASSPA THSPHA TRHPHA TMPSFA', 'Hydrothermal Vent Chemistry'],
-                ['HPIESA', 'Water Velocity'],
-                ['TMPSFA HPIESA', 'Water Temperature'],
-                ['BOTPTA', 'Seafloor Pressure'],
-                ['OBSBBA OBSSPA', 'Seismic Activity'],
-                ['PRESFA PRESFB PRESFC PRESTA PRESTB HPIESA', 'Seafloor Pressure']
+                ['HYDBBA HYDLFA HYDHydroFloor', 'Hydrophone'],
+                ['MASSPA THSPHA TRHPHA TMPSFA TMPHydroThermal', 'Hydrothermal Vent Chemistry'],
+                ['HPIESA HPIESWaterVelo', 'Water Velocity'],
+                ['TMPSFA HPIESA TMPPIEWaterTemp', 'Water Temperature'],
+                ['OBSBBA OBSSPA OBSSeismic', 'Seismic Activity'],
+                ['BOTPTA PRESFA PRESFB PRESFC PRESTA PRESTB HPIESA PRESSeaFloorPress', 'Seafloor Pressure']
             ],
             "Large Format Data":[
-                ['HYDBBA HYDLFA', 'Hydrophone'],
-                ['CAMDSC CAMDSB', 'Still Images'],
-                ['CAMHDA', 'HD Video'],
-                ['ZPLSCB ZPLSCC', 'Bioacoustic Sonar'],
-                ['OBSBBA OBSSPA', 'Seismic Activity']
+                ['HYDBBA HYDLFA HYDHydrophoneLarge', 'Hydrophone'],
+                ['CAMDSC CAMDSB CAMLarge', 'Still Images'],
+                ['CAMHDA HDLarge', 'HD Video'],
+                ['ZPLSCB ZPLSCC ZPLBioacousticLarge', 'Bioacoustic Sonar'],
+                ['OBSBBA OBSSPA OBSSeismicLarge', 'Seismic Activity']
             ]
         }
     }


### PR DESCRIPTION
Added in bogus instruments so that each scientific concept is a unique search field.  This fixes the bug where after selecting a scientific concept the filter would select the first item in the list with the same instrument list.  

@FBRTMaka Quick Turnaround check please?

@oceanzus Once this is in it should go to the test server.  