### PR TITLE
Fixed an issue with the map reset button.

### DIFF
--- a/ooiui/static/js/views/common/MapView.js
+++ b/ooiui/static/js/views/common/MapView.js
@@ -23,7 +23,7 @@ var MapView = Backbone.View.extend({
 
 
         L.control.mousePosition().addTo(this.map);
-
+        var self = this
         L.easyButton('fa-globe', function(btn, map){
             map.fitBounds(self.inititalMapBounds);
         },"Reset Zoom Level").addTo( this.map );


### PR DESCRIPTION
Fixed an issue in which `map.fitBounds` was being called when the map reset button was pressed and passed in `self.initialMapBouds`. In this case self was undefined so I defined it to be equal to this.