### PR TITLE
Reverts 2015 fix to user_name string passed during a download request (14279)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -69,13 +69,14 @@
     "mapbox-gl-js": "https://github.com/mapbox/mapbox-gl-js.git#0.17.0",
     "mapbox.js": "~3.0.1",
     "leaflet-plugins": "~3.0.0",
-    "Leaflet.Coordinates" : "https://github.com/MrMufflon/Leaflet.Coordinates.git#v0.1.5",
-    "Leaflet.Rrose" : "https://github.com/erictheise/rrose.git#v0.2.0",
-    "leaflet-omnivore" : "~v0.3.4",
-    "intro.js" : "~v2.9.3"
+    "Leaflet.Coordinates": "https://github.com/MrMufflon/Leaflet.Coordinates.git#v0.1.5",
+    "Leaflet.Rrose": "https://github.com/erictheise/rrose.git#v0.2.0",
+    "leaflet-omnivore": "~v0.3.4",
+    "intro.js": "~v2.9.3"
   },
   "resolutions": {
     "jquery": "~2.1.1",
-    "bootstrap": "~3.3.1"
+    "bootstrap": "~3.3.1",
+    "d3": "~3.4.13"
   }
 }

--- a/ooiui/static/js/partials/StreamDownloadForm.html
+++ b/ooiui/static/js/partials/StreamDownloadForm.html
@@ -87,7 +87,7 @@
             <div class="col-md-6">
               <div class="form-group">
                 <label for="dlEmail">Delivery Email</label>
-                <input class="form-control" id="dlEmail" type="text" name="email" size="25" placeholder="Enter Email">
+                <input class="form-control" id="dlEmail" type="text" name="email" size="25" placeholder="Enter Email" disabled>
               </div>
             </div>
             <div class="col-md-6">

--- a/ooiui/static/js/views/science/StreamDownloadFormView.js
+++ b/ooiui/static/js/views/science/StreamDownloadFormView.js
@@ -282,22 +282,6 @@ var StreamDownloadFormView = Backbone.View.extend({
     var email = this.$el.find('#dlEmail').val();
     var user_name = this.model.get('user_name');
     localModel.set('email', email);
-    /* 10/08/2015 @ 9:37am
-     * M@Campbell
-     *
-     * Recipient was trying to create a directory of the user name,
-     * which sometimes could be the user's email address.
-     *
-     * Lets remove the special characters; replace the @ with a - and
-     * completely remove the .
-     */
-    if (user_name.indexOf('.') > -1) { user_name = user_name.replace('.', '-'); }
-    if (user_name.indexOf('@') > -1) { user_name = user_name.replace('@', '-'); }
-
-    if (user_name.indexOf('.') > -1) {
-        var splitUserName = user_name.split('.');
-        user_name = splitUserName[0];
-    }
     localModel.set('user_name', user_name);
 
     // Check for provenance and set the model
@@ -373,22 +357,6 @@ var StreamDownloadFormView = Backbone.View.extend({
     var email = this.$el.find('#dlEmail').val();
     var user_name = this.model.get('user_name');
     localModel.set('email', email);
-    /* 10/08/2015 @ 9:37am
-     * M@Campbell
-     *
-     * Recipient was trying to create a directory of the user name,
-     * which sometimes could be the user's email address.
-     *
-     * Lets remove the special characters; replace the @ with a - and
-     * completely remove the .
-     */
-    if (user_name.indexOf('.') > -1) { user_name = user_name.replace('.', '-'); }
-    if (user_name.indexOf('@') > -1) { user_name = user_name.replace('@', '-'); }
-
-    if (user_name.indexOf('.') > -1) {
-        var splitUserName = user_name.split('.');
-        user_name = splitUserName[0];
-    }
     localModel.set('user_name', user_name);
 
     // Check for provenance and set the model

--- a/ooiui/static/json/uiPatchNotes.json
+++ b/ooiui/static/json/uiPatchNotes.json
@@ -1,9 +1,9 @@
 [
   {
-        "VersionNumber": "1.6.1",
-        "VersionDate": "2019-03-26",
+        "VersionNumber": "1.6.2",
+        "VersionDate": "2019-05-14",
         "VersionDescription": [
-            "Data Download: Fixes time and size estimator launching erroneous download attempts. (14251)"
+            "Data Download: Removes deprecated fix for user_name passed during download requests. (14279)"
         ],
         "ReleaseNotesPDF": "OOI_2.0_1.6.0.pdf",
         "SiteTourTitle": "Release 1.6.0 Tour",
@@ -45,6 +45,13 @@
                 }
             ]
         }
+  },
+      {
+        "VersionNumber": "1.6.1",
+        "VersionDate": "2019-03-26",
+        "VersionDescription": [
+            "Data Download: Fixes time and size estimator launching erroneous download attempts. (14251)"
+        ]
   },
   {
         "VersionNumber": "1.6.0",


### PR DESCRIPTION
Updates patch notes.
Minor fix to bower.json applied.